### PR TITLE
[Backend] updated list endpoints

### DIFF
--- a/capp-connect/backend/ccserver/serializers.py
+++ b/capp-connect/backend/ccserver/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-
+import re
 from .models import Comment, Post, Profile, ProfileTag, Resource, Tag
 
 
@@ -15,10 +15,12 @@ class TagSerializer(serializers.HyperlinkedModelSerializer):
 class NameSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Profile
-        fields = ["user"]
+        fields = ["slack_username"]
 
     def to_representation(self, instance):
-        return instance.user.username
+        slack_name = instance.slack_username
+        cleaned_name = re.sub(r'\(.*?\)', '', slack_name).strip()
+        return cleaned_name
 
 
 class ProfileSerializer(serializers.HyperlinkedModelSerializer):

--- a/capp-connect/backend/ccserver/views.py
+++ b/capp-connect/backend/ccserver/views.py
@@ -68,14 +68,16 @@ class GetProfileList(APIView):
         return Response(serializer.data)
 
 
-class GetNamesList(APIView):
+class SearchDirectoryList(APIView):
     def get(self, request, format=None):
         users = Profile.objects.all()
-        serializer = NameSerializer(users, many=True)
-        return Response(serializer.data)
+        user_serializer = NameSerializer(users, many=True)
+        tags = Tag.objects.filter(allowed_on_profile=True)
+        tag_serializer = TagSerializer(tags, many=True)
+        return Response({"users": user_serializer.data, "tags": tag_serializer.data})
 
 
-class GetTagsList(APIView):
+class SearchOthersList(APIView):
     def get(self, request, format=None):
         tags = Tag.objects.all()
         serializer = TagSerializer(tags, many=True)

--- a/capp-connect/backend/connect/urls.py
+++ b/capp-connect/backend/connect/urls.py
@@ -58,8 +58,8 @@ urlpatterns = [
         views.SearchPosts.as_view(),
         name="search_posts",
     ),
-    path("ccserver/tags/", views.GetTagsList.as_view(), name="get_tags"),
-    path("ccserver/names/", views.GetNamesList.as_view(), name="get_names"),
+    path("ccserver/tags/", views.SearchOthersList.as_view(), name="tags_list"),
+    path("ccserver/directory/", views.SearchDirectoryList.as_view(), name="directory_list"),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)


### PR DESCRIPTION
Different endpoints that create lists based on:
- All tags: Posts, Resources
- Some tags and users names: Directory

This is an improvement from the previous iteration. Includes a filter based on a new column from tags and has name 
(without year) instead of user_name.