### PR TITLE
[BUG] Message db integration debug

### DIFF
--- a/capp-connect/backend/ccserver/serializers.py
+++ b/capp-connect/backend/ccserver/serializers.py
@@ -119,6 +119,7 @@ class PostSerializer(serializers.HyperlinkedModelSerializer):
             "links",
             "start_time",
             "location",
+            "slack_ts"
         ]
         unique_together = ("post_id", "tag")
 

--- a/capp-connect/backend/ccserver/views.py
+++ b/capp-connect/backend/ccserver/views.py
@@ -345,9 +345,9 @@ class MyProfileView(APIView):
 class SlackPost(APIView):
     authentication_classes = [TokenAuthentication]
 
-    def get_object(self, ts, post_type):
+    def get_object(self, slack_ts, post_type):
         try:
-            return Post.objects.get(ts=ts, post_type=post_type)
+            return Post.objects.get(slack_ts=slack_ts, post_type=post_type)
         except Post.DoesNotExist:
             return None
 
@@ -359,9 +359,9 @@ class SlackPost(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def put(self, request):
-        ts = request.data.get("ts")
+        slack_ts = request.data.get("slack_ts")
         post_type = request.data.get("post_type")
-        post = self.get_object(ts, post_type)
+        post = self.get_object(slack_ts, post_type)
         if not post:
             return Response(
                 {"error": "Post not found."},
@@ -374,9 +374,9 @@ class SlackPost(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request):
-        ts = request.data.get("ts")
+        slack_ts = request.data.get("slack_ts")
         post_type = request.data.get("post_type")
-        post = self.get_object(ts, post_type)
+        post = self.get_object(slack_ts, post_type)
         if post:
             post.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
This pull request unifies the slack_ts field in views and serializers to match models. I tested all endpoints again, and this avoids inconsistencies when using them. 

In socket_mode.py, all the points where ts is being defined for the database must be named slack_ts (lines: 264, 328 (already well defined), and 341). I didn't change that file in case there were uncommitted changes.

It would be good to check that the json we are sending to the endpoints has the same name fields as models.py expected, in case some other fields are failing to.